### PR TITLE
Implement simple Flask trading terminal

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,107 @@
+import os
+import json
+import requests
+from flask import Flask, render_template, request, redirect, url_for, session
+import openai
+
+app = Flask(__name__)
+app.secret_key = os.getenv('FLASK_SECRET_KEY', 'secret-key')
+openai.api_key = os.getenv('OPENAI_API_KEY')
+
+rsi_data = {
+    'BTC': 40,
+    'ETH': 60,
+    'ADA': 55,
+    'SOL': 30,
+}
+
+SYSTEM_PROMPT = (
+    "You are a smart and calm AI crypto trader. "
+    "Answer concisely and use markdown when helpful."
+)
+
+
+@app.route('/')
+def index():
+    if 'messages' not in session:
+        session['messages'] = [{'role': 'system', 'content': 'Welcome to the trading terminal.'}]
+    return render_template('index.html', messages=session['messages'])
+
+
+def call_openai(user_msg):
+    messages = [{'role': 'system', 'content': SYSTEM_PROMPT}]
+    for m in session.get('messages', []):
+        if m['role'] != 'system':
+            messages.append({'role': m['role'], 'content': m['content']})
+    messages.append({'role': 'user', 'content': user_msg})
+    rsi_json = json.dumps(rsi_data)
+    messages.append({'role': 'system', 'content': f'Current RSI data: {rsi_json}'})
+    try:
+        res = openai.ChatCompletion.create(
+            model='gpt-4o',
+            messages=messages,
+        )
+        reply = res.choices[0].message.content
+        return reply
+    except Exception as e:
+        return f"Error communicating with GPT: {e}"
+
+
+def send_trade(pair):
+    url = 'https://app.3commas.io/trade_signal/trading_view'
+    payload = {
+        'message_type': 'bot',
+        'bot_id': int(os.getenv('BOT_ID', '0')),
+        'email_token': os.getenv('EMAIL_TOKEN', ''),
+        'delay_seconds': 0,
+        'pair': pair,
+    }
+    try:
+        r = requests.post(url, json=payload)
+        r.raise_for_status()
+        return True
+    except Exception as e:
+        session['messages'].append({'role': 'system', 'content': f'Error sending trade: {e}'})
+        return False
+
+
+def send_telegram(text):
+    token = os.getenv('TELEGRAM_BOT_TOKEN')
+    chat_id = os.getenv('TELEGRAM_CHAT_ID')
+    if not token or not chat_id:
+        return
+    url = f'https://api.telegram.org/bot{token}/sendMessage'
+    try:
+        requests.post(url, data={'chat_id': chat_id, 'text': text})
+    except Exception:
+        pass
+
+
+@app.route('/chat', methods=['POST'])
+def chat():
+    msg = request.form.get('message')
+    if not msg:
+        return redirect(url_for('index'))
+    session.setdefault('messages', []).append({'role': 'user', 'content': msg})
+
+    reply = call_openai(msg)
+    session['messages'].append({'role': 'system', 'content': reply})
+
+    # Look for trading pair in reply like USD_TOKEN
+    pair = None
+    for word in reply.split():
+        if word.startswith('USD_'):
+            pair = word
+            break
+    if pair:
+        if send_trade(pair):
+            confirm = f'Trade sent for {pair}'
+            session['messages'].append({'role': 'system', 'content': confirm})
+            send_telegram(confirm)
+
+    session.modified = True
+    return redirect(url_for('index'))
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8080)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+openai
+requests

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,9 @@
+body { font-family: Arial, sans-serif; background: #f4f4f4; padding: 20px; }
+.chat-container { max-width: 600px; margin: auto; background: #fff; padding: 20px; border-radius: 5px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+.messages { height: 400px; overflow-y: auto; border: 1px solid #ddd; padding: 10px; margin-bottom: 10px; }
+.message { margin: 5px 0; }
+.message.user { text-align: right; color: #333; }
+.message.system { text-align: left; color: #0066cc; }
+form { display: flex; }
+input[type=text] { flex: 1; padding: 10px; border-radius: 5px 0 0 5px; border: 1px solid #ccc; }
+button { padding: 10px; border: none; background: #0066cc; color: white; border-radius: 0 5px 5px 0; cursor: pointer; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Crypto Trading Terminal</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<div class="chat-container">
+  <h2>Crypto Trading Terminal</h2>
+  <div class="messages" id="messages">
+    {% for m in messages %}
+      <div class="message {{ m.role }}">{{ m.content|safe }}</div>
+    {% endfor %}
+  </div>
+  <form action="/chat" method="post">
+    <input type="text" name="message" autocomplete="off" autofocus>
+    <button type="submit">Send</button>
+  </form>
+</div>
+<script>
+  const msgBox = document.getElementById('messages');
+  msgBox.scrollTop = msgBox.scrollHeight;
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add minimal Flask app to chat with GPT and send trades
- include simple HTML/CSS interface
- store API keys in environment variables

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6869c59f9e708331a2da577876448161